### PR TITLE
Fixes #5 Adds an operators option for sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ On the `users` data bag item:
 }
 ```
 
-This will add a `/etc/sudoers.d/newuser` file with privileges allowing the user to execute any command as root. The user will have to enter their password. The recipe uses the `sudo` resource and some features of that can be overwritten, namely `nopasswd`, `commands` and `defaults`. For example:
+This will add a `/etc/sudoers.d/newuser` file with privileges allowing the user to execute any command as root. The user will have to enter their password. The recipe uses the `sudo` resource and some features of that can be overwritten, namely `nopasswd`, `commands`, `runas` and `defaults`. For example:
 
 ```
 {

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -52,7 +52,7 @@ users.each do |username, user_data|
 
   sudo username.delete('.') do # Filenames in /etc/sudoers.d that contain dots are ignored
     user username
-    runas 'root'
+    runas user_data['sudo']['runas'] if user_data['sudo'] && user_data['sudo']['runas']
     nopasswd user_data['sudo']['nopasswd'] if user_data['sudo'] && user_data['sudo']['nopasswd']
     commands user_data['sudo']['commands'] if user_data['sudo'] && user_data['sudo']['commands']
     defaults user_data['sudo']['defaults'] if user_data['sudo'] && user_data['sudo']['defaults']

--- a/test/fixtures/data_bags/common/users.json
+++ b/test/fixtures/data_bags/common/users.json
@@ -1,26 +1,26 @@
 {
   "id": "users",
   "testuser": {
-    "encrypted_data": "YBwSFPrNHRv91M7YJygQ76qRNwHgoFNzCIsNHp9X6IY=\n",
-    "iv": "GQzRBg8qCuFdrtgQznnS6w==\n",
+    "encrypted_data": "zey7gGWUhd/NBNYf8SYz8MvsSfaqnadoVLPGj8Wz6RQ=\n",
+    "iv": "wPXTuTihldqX0LNB1iPpBw==\n",
     "version": 1,
     "cipher": "aes-256-cbc"
   },
   "newuser1": {
-    "encrypted_data": "uc57Ti7L6v6zqWPW4BhI/XvGNvzIECYCerBO6fJGNQo=\n",
-    "iv": "ngiH1BQ4jXeb6O7njOC04g==\n",
+    "encrypted_data": "zS7AP5OBwmfpHr3TGyGB7b6LYK9qbm3zA3uyS+fl+hA=\n",
+    "iv": "cSRPtTLLlkIyv1JzL4c1ZQ==\n",
     "version": 1,
     "cipher": "aes-256-cbc"
   },
   "newuser2": {
-    "encrypted_data": "vzlygHzFtaa8q5GzrKKW7Rgqas8KU6TkGh18GjSViA/FCorutxWUWv2S041S\nlK6JhQlqim4rsz4Pf8d7CAcmVLCsjYl9oYjahPB0JHBU5XoNOWpIHSKw5Xew\n8kpExpdpkm0oENzQrZuDdwhxA/OhkREX7KvU53SBP8aJ4Scf90OXEhIE3Eec\nhgdFmsDWJMA8JmxfnkqTQ85yDlwtXXDIHxujrP7dNRKihQBpxXZFlU+VUi/U\nWJMqVfGx2O+uncynHm/SpgirGeKe8ubCcMqQ6FQY8BfkoT/nc/c3durrxE1m\naBhY1cxvaKKIHAsMJ6bFy+NEy3iNHNRgUlktNSrr9L3WnswOjF2Qx74RjupG\nkwrmNZvOZrNrucYG13n/nOhC3fnL/KoD+AgB04pNDy5O9ufkIywia7+SYR2Y\nyLRXdTYNEg4SBtri1nS0O+375T8S7t0jQQapUGgwr8MeV0SaAvWurlaYpAyx\n6yVk3dsKorVrlhURhRKJDFP2x9vMeoy/b3/qAl/Y+Tk3fiZXMg91+UKq7YoD\nca6c8qutcOKa3jDQxUvXBpWedcOiMfBR4/hS1scpClKXqw8+cVrYUdE9aXqZ\nCSjW0DQ+CY6lsFH66o2vKdi8JVaNn0GoY0ZDjkEdLYPJ9NHcxBrdNHl+obkP\nDlnJfLMxM65Lnz3P1myINOsX3o52omIdRG6Cph6biXFoj2mO1XRU2r0rbCRk\nsTOIrA==\n",
-    "iv": "fxWPP4F1e01ObiOQQ9oq6Q==\n",
+    "encrypted_data": "p05e3MmOfBHs87IX0w8OmUxWbzisDKXF2afK4qID+CNWh0UC7s/kzSlHSH4z\nAZFaSkYxzKgBON58l6zD2r8IuH24mEOVYmJAWazpRtlsBykutpDgfDeyT/ln\nPyo3f1bzf/88t/tcDKxUfqSyuCazTtzYjd7Nr0oyOyqaS+3KasTLied//Jy9\n0fx+wg4RnkSkoxk3smwdANv0gVepit0nrphibfT4nO20PdbRvwmJaey8TpVZ\nefl3tgOPjLStYLKT230qrWd2iFqqgOWmtS8vwX8HA23K2zq+L0HhHHGYDAEs\nK8cL8b/fhRvqRdlHeZdNEudXfWIQh0j7Nz85Fl0bUfKlHEFQlEeScCGvNDQ8\nFybTFeWxkQ4frnzRMjnfHX8U+BZuXGlSZkQTJzgtIZTv864HX4tlAwwlSj9H\nFvuB0ircIPTs+FYThaeBmDs9Q4rN0/2NNneigMJ2U1fZfrtJIHuPG1OXKufq\nFTZJnAahO9+VoYxomIdrhr/NmOdBzfZXQtVGJ43Pf2zUPFl9nehlKSQaSZsB\n1lvMqlOWAsqqvIxZbeI93YWd5ZxmDnwaBrtHdZxYESRQhxIh3CYRrNHPiDvV\naXgBJL+mXQZZ2v8NLChAOO+tMydpPoFtqL5UmdGuZOzcK3ffY4m9r3RYCkeo\n/0vPs3sq8DwDCwm8feNedkc6Uew7tNyzXtGy8Rgs4UT3xRuB2yKPuthM/umO\n2ynNDiD1pLssPL6ELEdiFMkXSVk=\n",
+    "iv": "ozSAo8mnnbAbkomQ1YecUg==\n",
     "version": 1,
     "cipher": "aes-256-cbc"
   },
   "olduser": {
-    "encrypted_data": "RcePe60AAxJB2XgqdFCBi1fsJLlupBIo61HjazTh4+47Bmj+EiFZfN75Z7IX\nAymx\n",
-    "iv": "wGoqDinPKsuMarEcNBt1UQ==\n",
+    "encrypted_data": "fBodNiYvpx846i1ZFjPtFaeu3PxBmTfmkXOjc7xsT/GAr/oI01mgbP7ysiVU\nOo6L\n",
+    "iv": "lpOT+Eq+PBWJYeMEiIkfqg==\n",
     "version": 1,
     "cipher": "aes-256-cbc"
   }

--- a/test/fixtures/data_bags/staging/users.json
+++ b/test/fixtures/data_bags/staging/users.json
@@ -1,26 +1,26 @@
 {
   "id": "users",
   "newuser1": {
-    "encrypted_data": "PY8vQUtFEqvjZHxNF0lYHaftvWiKRU4q+y060a/kgg7iwdQ/5VEwPsDfIy8Y\nmVArhVihL8HWypNAf18sgIO+NvlTFdhcE0JYPnuHSCdI903stONc9LQFO6g6\nfTr5xH5XFZFaIorzli5ffdfxFcbH8g==\n",
-    "iv": "ZwFSF9Dsosjn8Q9wcBd50g==\n",
+    "encrypted_data": "+R4sDarfIKrjcnS+lE04SYZ7weIZl+Q2/uGibMmgBP7rl6ACfM6WOVI3pi7m\noRr7tUsJ5IbnYtj9fTgPyprDUnhex5FE7RojT3fawc8ILLJLANSCr5g2tL1p\nc161Ys9rBPfjZ38pinToCdQ7FLJD1w==\n",
+    "iv": "BET1rtyCNXDJBqhy7RGjhQ==\n",
     "version": 1,
     "cipher": "aes-256-cbc"
   },
   "newuser2": {
-    "encrypted_data": "bqygMUgKd7WD1qB6T/MRebmRoOptWFMD2SbDa7AurB2I82tM1F5uILLNjZTa\n/clhy+nwVTCtnan5Txj/4Kt5EZmrnveYKvb8mVsjJwtW81bDrNjHwQgzIGBh\nvQB1BdnIzmF8v6jO30vwgT111G5JfHar8KuJY6Jve31yQ4Q4NtPItmHbBJS+\nmscS79vyGwsM\n",
-    "iv": "EMePVJu918DdesQOvIaTZA==\n",
+    "encrypted_data": "2Rqp7yiL7dtOMdh0j8NgDR0a5Uy/7Q/sX+Muer2YujtFoWIeF0SCbLZBStjC\n84YhXK8FU+ajVToRvkYA2av1voifRVt9YndLDwsH2KfMPtDyi2YXK3zBGvu2\n725B7PAAvc7wjv2wIUSOA5/mCikotvy3enSVNFIZZx1ZwaCptByI0VzdbpXu\n+0E5WYMKGVYm\n",
+    "iv": "1nwH9SvP/ko/3OvnDYGEJw==\n",
     "version": 1,
     "cipher": "aes-256-cbc"
   },
   "newuser3": {
-    "encrypted_data": "RG2w9wAdSVpV30BERTqMH/UKn+O6vu7E76qP2pHB7RVOzZUlvk9XiHw0yJoT\n8uMNqs3YoPYc8gNB9ZkqwYX7k/wWZxk8WDTfflsohhiy30E=\n",
-    "iv": "YyPnxVBknywEhjnQqAiTaQ==\n",
+    "encrypted_data": "Ksb+syx3JayO7yYStbJry8q25Zg+cBf69RaXWQdbFR+S9f0w0kRpeA0BzERh\nviEXUm6sHgezqkVOabhv/nudv5eTZUXR8YANdgzRuONwQR4=\n",
+    "iv": "PrPiQ0ifqt1ATVI48F6zDw==\n",
     "version": 1,
     "cipher": "aes-256-cbc"
   },
   "olduser": {
-    "encrypted_data": "/T0LR6Bw/xod4nmYBJw+HjO7iSatU6UCaR4kGvvFu59uySO3pZHx/zvz3koH\no/Xz\n",
-    "iv": "7xM95B1rfejJgJsU2TJMiQ==\n",
+    "encrypted_data": "e7B9Q+nuS0vwgpM+EZR853zGmkj1H8rjIK+LdhA5nhodqn9KVF1lvL0ePFZ0\n3WL4\n",
+    "iv": "fBf2tMzCBaHK1HZjSPVTPQ==\n",
     "version": 1,
     "cipher": "aes-256-cbc"
   }

--- a/test/integration/helpers/serverspec/shared_examples.rb
+++ b/test/integration/helpers/serverspec/shared_examples.rb
@@ -23,6 +23,10 @@ shared_examples_for 'users' do
     it { should belong_to_group 'newuser1' }
   end
 
+  describe file('/etc/sudoers.d/newuser1') do
+    its(:content) { should match(/newuser1 ALL=\(ALL\) ALL/) }
+  end
+
   # newuser2
   describe group('newgroup') do
     it { should exist }
@@ -101,7 +105,7 @@ shared_examples_for 'users override' do
 
   describe file('/etc/sudoers.d/newuser1') do
     it { should exist }
-    its(:content) { should match(/newuser1 ALL=\(root\) ALL/) }
+    its(:content) { should match(/newuser1 ALL=\(ALL\) ALL/) }
   end
 
   # newuser2

--- a/test/unit/spec/fixtures/databags/common/users.json
+++ b/test/unit/spec/fixtures/databags/common/users.json
@@ -1,6 +1,7 @@
 {
   "id": "users",
   "testuser": {
+
   },
   "newuser1": {
     "sudo": {
@@ -30,6 +31,7 @@
     "sp_warn": 5,
     "sudo": {
       "nopasswd": true,
+      "runas": "root",
       "commands": [
         "/etc/init.d/httpd restart",
         "/sbin/iptables"

--- a/test/unit/spec/rackspace_users_shared.rb
+++ b/test/unit/spec/rackspace_users_shared.rb
@@ -25,7 +25,7 @@ shared_examples_for 'users' do
     expect(chef_run).to modify_shadow_attributes('newuser1')
     expect(chef_run).to install_sudo('newuser1').with(
       user: 'newuser1',
-      runas: 'root',
+      runas: 'ALL',
       nopasswd: false
     )
   end
@@ -81,7 +81,7 @@ shared_examples_for 'users override' do
     expect(chef_run).to modify_shadow_attributes('newuser1')
     expect(chef_run).to install_sudo('newuser1').with(
       user: 'newuser1',
-      runas: 'root',
+      runas: 'ALL',
       nopasswd: false
     )
   end


### PR DESCRIPTION
Added a change to allow configuring the `runas` option for the sudo resource and fall back to their default.

The default is ALL which includes all users in the system. The purpose of the operators in sudo is to limit access away from root if needed, which should be allowed and configured through the users data bag as the other options in the cookbook allow.
