### PR TITLE
Using latest Rackspace CentOS cloud image for test

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -11,7 +11,7 @@ provisioner:
     environment: 'staging'
 
 platforms:
-  - name: centos-6.6
+  - name: centos-6
   - name: ubuntu-12.04
   - name: ubuntu-14.04
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A cookbook to manage users from an encrypted data bag.
 
 ## Supported Platforms
 
-* Centos 6.6
+* Centos 6.7
 * Ubuntu 12.04
 * Ubuntu 14.04
 


### PR DESCRIPTION
Tests were failing today with 

```
Kitchen::UserError: Kitchen::Driver::Rackspace<default-centos-66>#config[:image_id] cannot be blank
```
